### PR TITLE
Check if window.navigator.serial exists for setting flashing.supported

### DIFF
--- a/flasher.js
+++ b/flasher.js
@@ -101,7 +101,7 @@ function setup() {
   }
 
   const flashing = reactive({
-    supported: 'Serial' in window,
+    supported: 'Serial' in window || 'serial' in window.navigator,
     instance: null,
     active: false,
     percentage: 0,


### PR DESCRIPTION
Closes #1

based on my comment on the issue:

> I was just looking into this today. The flasher works perfectly with the WebSerial extension, and as it turns out, the proper way to check if WebSerial API is supported is by querying `navigator.serial` and not `window.Serial`
> 
> https://developer.mozilla.org/en-US/docs/Web/API/Navigator/serial

and these are the results from my browser with the WebSerial extension enabled:

```js
>> window.navigator.serial

Object { addEventListener: BoundFunctionObject, dispatchEvent: BoundFunctionObject, getPorts: BoundFunctionObject, removeEventListener: BoundFunctionObject, requestPort: BoundFunctionObject }
```